### PR TITLE
autodetect and allow for override of ESP

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,9 @@ cd refind2k
 ./setup.sh
 # To uninstall refind2k run setup.sh with -u or --uninstall
 ./setup.sh -u
+# To use a custom ESP, set the ESP envvar
+ESP=/path/to/efi ./setup.sh
+ESP=/path/to/efi ./setup.sh -u
 ```
 
 ## Customizations

--- a/setup.sh
+++ b/setup.sh
@@ -1,19 +1,35 @@
 #!/bin/bash
 
+echo -e "\u001b[32;1mWelocme to refind2k...\u001b[0m"
+echo -e "\u001b[31;1mWarning! sudo password is required.\u001b[0m"
+
+# Detect ESP location, unless user override provided
+# NOTE: does not check actual partitions, as someone may have >1 ESP
+if [ -z "$ESP" ]; then
+    if [ -d "/boot/efi/EFI" ]; then
+        ESP="/boot/efi"
+    elif [ -d "/boot/EFI" ]; then
+        ESP="/boot"
+    elif [ -d "/efi/EFI" ]; then
+        ESP="/efi"
+    else
+        ESP="/boot/efi"
+        echo -e "\u001b[33;1mwarn: could not find ESP, falling back to /boot/efi\u001b[0m"
+        echo -e "\u001b[33;1mwarn: run ESP=/path/to/esp $0 to override\u001b[0m"
+    fi
+fi
+
 function setup_refind {
-    sudo cp /boot/efi/EFI/refind/refind.conf /boot/efi/EFI/refind/refind.conf.bak
-    echo "include refind2k/refind2k.conf" | sudo tee /boot/efi/EFI/refind/refind.conf
-    sudo mkdir -p /boot/efi/EFI/refind/refind2k
-    sudo cp -r banners/ icons/ refind2k.conf /boot/efi/EFI/refind/refind2k/
+    sudo cp "$ESP/EFI/refind/refind.conf" "$ESP/EFI/refind/refind.conf.bak"
+    echo "include refind2k/refind2k.conf" | sudo tee "$ESP/EFI/refind/refind.conf"
+    sudo mkdir -p "$ESP/EFI/refind/refind2k"
+    sudo cp -r banners/ icons/ refind2k.conf "$ESP/EFI/refind/refind2k/"
 }
 
 function uninstall_refind {
-    sudo cp /boot/efi/EFI/refind/refind.conf.bak /boot/efi/EFI/refind/refind.conf
-    sudo rm -rf /boot/efi/EFI/refind/refind2k
+    sudo cp "$ESP/EFI/refind/refind.conf.bak" "$ESP/EFI/refind/refind.conf"
+    sudo rm -rf "$ESP/EFI/refind/refind2k"
 }
-
-echo -e "\u001b[32;1mWelocme to refind2k...\u001b[0m"
-echo -e "\u001b[31;1mWarning! sudo password is required.\u001b[0m"
 
 if [ "$1" == "-u" ] || [ "$1" == "--uninstall" ]; then
     uninstall_refind


### PR DESCRIPTION
## What

What does this pull request accomplish?

- [x] Autodetects ESP location (searches `/boot/efi`, `/boot`, `/efi`)
- [x] Allows user to override ESP by setting `ESP=/path/to/esp`
- [x] Fixes #2 
- [x] Alert users in README of ability to override ESP

## How

What code changes were made to accomplish it?

- Move the placement of the function definitions to after the initialization, thus letting them properly reference `$ESP`
- If-tree searching for the location of the `ESP` with a fallback to `/boot/efi`

## Why

- [x] I want to fix the issue #2 
- [x] I want to add a new feature (ESP autodetection and overriding)
- [x] I want to improve the documentation (let users know about override)

## Notes
Passes `shellcheck` linting with no warnings

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
