### PR TITLE
Add -a parameter to tee command in setup.sh to prevent file overwriting

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -21,7 +21,7 @@ fi
 
 function setup_refind {
     sudo cp "$ESP/EFI/refind/refind.conf" "$ESP/EFI/refind/refind.conf.bak"
-    echo "include refind2k/refind2k.conf" | sudo tee "$ESP/EFI/refind/refind.conf"
+    echo "include refind2k/refind2k.conf" | sudo tee -a "$ESP/EFI/refind/refind.conf"
     sudo mkdir -p "$ESP/EFI/refind/refind2k"
     sudo cp -r banners/ icons/ refind2k.conf "$ESP/EFI/refind/refind2k/"
 }


### PR DESCRIPTION
## What

What does this pull request accomplish?

- [x] Prevent overwriting of configuration in `refind.conf`

## How

What code changes were made to accomplish it?

- Modified the `tee` command in `setup.sh` on line 24 to include the `-a` option. This ensures that `include refind2k/refind2k.conf` is appended to `refind.conf` instead of overwriting it.

## Why

- [x] I want to fix the issue #5 

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
